### PR TITLE
Light touches for catalog vocabulary

### DIFF
--- a/freanalysis_clouds/freanalysis_clouds/__init__.py
+++ b/freanalysis_clouds/freanalysis_clouds/__init__.py
@@ -36,6 +36,7 @@ class Metadata:
 
     def catalog_key(self, name) -> str:
         return ".".join([
+            self.source_id,
             self.experiment_id,
             self.frequency,
             self.member_id,

--- a/freanalysis_clouds/freanalysis_clouds/__init__.py
+++ b/freanalysis_clouds/freanalysis_clouds/__init__.py
@@ -13,8 +13,8 @@ class Metadata:
     activity_id: str = "dev"
     institution_id: str = ""
     source_id: str = ""
-    experiment_id: str = "c96L65_am5f4b4r1-newrad_amip"
-    frequency: str = "monthly"
+    experiment_id: str = "c96L65_am5f7b11r0_amip"
+    frequency: str = "P1M"
     modeling_realm: str = "atmos"
     table_id: str = ""
     member_id: str = "na"
@@ -23,6 +23,7 @@ class Metadata:
     chunk_freq: str = ""
     platform: str = ""
     cell_methods: str = ""
+    chunk_freq: str = "P1Y"
 
     def catalog_search_args(self, name):
         return {
@@ -40,6 +41,7 @@ class Metadata:
             self.member_id,
             self.modeling_realm,
             name,
+            self.chunk_freq
         ])
 
     def variables(self):
@@ -125,7 +127,7 @@ class AerosolAnalysisScript(AnalysisScript):
                 datasets[self.metadata.catalog_key(variable)],
                 variable,
                 time_method="annual mean",
-                year=2010,
+                year=1980,
             )
 
         figure = Figure(num_rows=3, num_columns=1, title="Cloud Fraction", size=(16, 10))

--- a/raytest.py
+++ b/raytest.py
@@ -1,0 +1,8 @@
+#!/home/a1r/env/bin/python
+
+from freanalysis.plugins import list_plugins, plugin_requirements, run_plugin
+name = "freanalysis_clouds"
+reqs = plugin_requirements(name)
+print(reqs)
+catalog = "/home/a1r/cat/canopy/am5f7b11r0/c96L65_am5f7b11r0_amipnew.json" #"/home/a1r/cat/canopy/am5f7b11r0/c96L65_am5f7b11r0_amipn0513.json" 
+run_plugin(name, catalog, "pngs")


### PR DESCRIPTION
@aradhakrishnanGFDL ran the scripts with sample output from the current catalog builder, and found it almost worked, and needed one small change-- adding `chunk_freq` because it is one of the `aggregate_columns` set in the catalog schema:

https://github.com/aradhakrishnanGFDL/CatalogBuilder/blob/main/cats/gfdl_template.json

Also, `frequency` values should eventually match those in this CV location. `monthly` is the Bronx DRS pattern, `P1M` is the Canopy DRS pattern, and `mon` is the agreed standard based on community use:

https://github.com/NOAA-GFDL/CMIP6_CVs/blob/main/CMIP6_frequency.json